### PR TITLE
Update readme with Docker images. Addresses issue #24.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ information.
 
 * [Local install and dependencies](http://neon.nervanasys.com/docs/latest/installation.html)
 * Cloud-based access ([email us](mailto:demo@nervanasys.com) for an account)
+* Docker images
+    * [Base (CPU-only)](https://registry.hub.docker.com/u/kaixhin/neon/)
+    * [nervanagpu backend](https://registry.hub.docker.com/u/kaixhin/nervanagpu-neon/)
+    * [cudanet backend](https://registry.hub.docker.com/u/kaixhin/cudanet-neon/)
 
 ### Quick Install
 


### PR DESCRIPTION
As per @kylef-lab41's request, I've included links to the Docker images in the readme. The GPU versions have the requirements written quite clearly, but let me know if there are any adjustments I should make. Overall this seems like a cleaner solution than trying to integrate Docker builds into the library itself.