### PR TITLE
Adds split_set to datasets. Closes issue #57 including comments from #58

### DIFF
--- a/examples/ANNOTATED_EXAMPLE.yaml
+++ b/examples/ANNOTATED_EXAMPLE.yaml
@@ -142,6 +142,8 @@
     #             the Iris dir directly)
     # sample_pct - if 100, full dataset will be used, otherwise we uniformly
     #              downsample records to the specified percentage
+    # validation_pct - creates validation dataset with this percentage of the 
+    #                  train set
     repo_path: '~/data',
     sample_pct: 100,
   },

--- a/neon/datasets/cifar10.py
+++ b/neon/datasets/cifar10.py
@@ -125,7 +125,7 @@ class CIFAR10(Dataset):
             self.targets['test'][:] = labels
             if hasattr(self, 'validation_pct'):
                 self.split_set(
-                    self.validation_pct, from_set='train', to_set='test')
+                    self.validation_pct, from_set='train', to_set='validation')
             self.format()
         else:
             raise AttributeError('repo_path not specified in config')

--- a/neon/datasets/cifar10.py
+++ b/neon/datasets/cifar10.py
@@ -123,6 +123,9 @@ class CIFAR10(Dataset):
                                             dtype='float32')
             self.inputs['test'][:] = data
             self.targets['test'][:] = labels
+            if hasattr(self, 'validation_pct'):
+                self.split_set(
+                    self.validation_pct, from_set='train', to_set='test')
             self.format()
         else:
             raise AttributeError('repo_path not specified in config')

--- a/neon/datasets/cifar100.py
+++ b/neon/datasets/cifar100.py
@@ -123,6 +123,9 @@ class CIFAR100(Dataset):
                                             dtype='float32')
             self.inputs['test'][:] = data
             self.targets['test'][:] = labels
+            if hasattr(self, 'validation_pct'):
+                self.split_set(
+                    self.validation_pct, from_set='train', to_set='test')
             self.format()
         else:
             raise AttributeError('repo_path not specified in config')

--- a/neon/datasets/cifar100.py
+++ b/neon/datasets/cifar100.py
@@ -125,7 +125,7 @@ class CIFAR100(Dataset):
             self.targets['test'][:] = labels
             if hasattr(self, 'validation_pct'):
                 self.split_set(
-                    self.validation_pct, from_set='train', to_set='test')
+                    self.validation_pct, from_set='train', to_set='validation')
             self.format()
         else:
             raise AttributeError('repo_path not specified in config')

--- a/neon/datasets/dataset.py
+++ b/neon/datasets/dataset.py
@@ -282,6 +282,7 @@ class Dataset(object):
             from_set (str): Where the data will be transfered from.
             to_set (str): The set to be created with the transfered data.
         """
+        np.random.seed(self.backend.rng_seed)
         to_set_inputs = []
         to_set_targets = []
         pct /= 100.0

--- a/neon/datasets/dataset.py
+++ b/neon/datasets/dataset.py
@@ -20,7 +20,6 @@ import logging
 import numpy as np
 import os
 from math import floor
-from random import randint
 
 from neon.backends.cpu import CPU
 from neon.util.compat import PY3, range
@@ -279,7 +278,7 @@ class Dataset(object):
         to_set.
 
         Arguments:
-            pct (float): The percentage of data to transfer, in [0 - 100].
+            pct (float): The percentage of data to transfer, in [0, 100].
             from_set (str): Where the data will be transfered from.
             to_set (str): The set to be created with the transfered data.
         """
@@ -288,7 +287,7 @@ class Dataset(object):
         pct /= 100.0
         nb_transfered = int(floor(pct * len(self.inputs[from_set])))
         for _ in range(nb_transfered):
-            idx = randint(0, self.inputs[from_set].shape[0] - 1)
+            idx = np.random.randint(0, self.inputs[from_set].shape[0])
             data = self.inputs[from_set][idx]
             target = self.targets[from_set][idx]
             to_set_inputs.append(data)

--- a/neon/datasets/housing.py
+++ b/neon/datasets/housing.py
@@ -116,6 +116,9 @@ class Housing(Dataset):
                 self.targets['train'] = lab
             if 'sample_pct' in self.__dict__:
                 self.sample_training_data()
+            if hasattr(self, 'validation_pct'):
+                self.split_set(
+                    self.validation_pct, from_set='train', to_set='test')
             self.format()
         else:
             raise AttributeError('repo_path not specified in config')

--- a/neon/datasets/housing.py
+++ b/neon/datasets/housing.py
@@ -118,7 +118,7 @@ class Housing(Dataset):
                 self.sample_training_data()
             if hasattr(self, 'validation_pct'):
                 self.split_set(
-                    self.validation_pct, from_set='train', to_set='test')
+                    self.validation_pct, from_set='train', to_set='validation')
             self.format()
         else:
             raise AttributeError('repo_path not specified in config')

--- a/neon/datasets/iris.py
+++ b/neon/datasets/iris.py
@@ -163,5 +163,5 @@ class Iris(Dataset):
             self.targets[name] = targets
         if hasattr(self, 'validation_pct'):
             self.split_set(
-                self.validation_pct, from_set='train', to_set='test')
+                self.validation_pct, from_set='train', to_set='validation')
         self.format()

--- a/neon/datasets/iris.py
+++ b/neon/datasets/iris.py
@@ -161,4 +161,7 @@ class Iris(Dataset):
                                     self.raw_onehot_targets[v_idcs, :],
                                     self.raw_onehot_targets[c_idcs, :]))
             self.targets[name] = targets
+        if hasattr(self, 'validation_pct'):
+            self.split_set(
+                self.validation_pct, from_set='train', to_set='test')
         self.format()

--- a/neon/datasets/mnist.py
+++ b/neon/datasets/mnist.py
@@ -146,6 +146,9 @@ class MNIST(Dataset):
                     logger.error('problems loading: %s', name)
             if 'sample_pct' in self.__dict__:
                 self.sample_training_data()
+            if hasattr(self, 'validation_pct'):
+                self.split_set(
+                    self.validation_pct, from_set='train', to_set='test')
             self.format()
         else:
             raise AttributeError('repo_path not specified in config')

--- a/neon/datasets/mnist.py
+++ b/neon/datasets/mnist.py
@@ -148,7 +148,7 @@ class MNIST(Dataset):
                 self.sample_training_data()
             if hasattr(self, 'validation_pct'):
                 self.split_set(
-                    self.validation_pct, from_set='train', to_set='test')
+                    self.validation_pct, from_set='train', to_set='validation')
             self.format()
         else:
             raise AttributeError('repo_path not specified in config')

--- a/neon/datasets/mobydick.py
+++ b/neon/datasets/mobydick.py
@@ -149,7 +149,7 @@ class MOBYDICK(Dataset):
                 self.targets[dataset] = offbyone
             if hasattr(self, 'validation_pct'):
                 self.split_set(
-                    self.validation_pct, from_set='train', to_set='test')
+                    self.validation_pct, from_set='train', to_set='validation')
             self.format(dtype=self.backend_type)  # runs transpose_batches
 
         else:

--- a/neon/datasets/mobydick.py
+++ b/neon/datasets/mobydick.py
@@ -147,6 +147,9 @@ class MOBYDICK(Dataset):
                 offbyone[0:length - self.data_dim, :] = splay_3d[self.data_dim:
                                                                  length, :]
                 self.targets[dataset] = offbyone
+            if hasattr(self, 'validation_pct'):
+                self.split_set(
+                    self.validation_pct, from_set='train', to_set='test')
             self.format(dtype=self.backend_type)  # runs transpose_batches
 
         else:

--- a/neon/datasets/sparsenet.py
+++ b/neon/datasets/sparsenet.py
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 
 
 class SPARSENET(Dataset):
+
     """
     Sets up a Sparsenet dataset.
 
@@ -104,9 +105,9 @@ class SPARSENET(Dataset):
                         data = infile[infile.keys()[0]]
                         # patches are extracted so they can be cached
                         # doing non-overlapping 16x16 patches (1024 per image)
-                        patches = data.reshape(512/16, 16, 512/16, 16, 10)
+                        patches = data.reshape(512 / 16, 16, 512 / 16, 16, 10)
                         patches = patches.transpose(1, 3, 0, 2, 4)
-                        patches = patches.reshape(16, 16, 1024*10)
+                        patches = patches.reshape(16, 16, 1024 * 10)
                         logger.info("Caching to pickle file: %s", outfile)
                         pickle.dump(patches, outfile)
                         outfile.close()
@@ -119,6 +120,9 @@ class SPARSENET(Dataset):
                     self.inputs['train'] = indat
                 else:
                     logger.error('problems loading: %s', name)
+            if hasattr(self, 'validation_pct'):
+                self.split_set(
+                    self.validation_pct, from_set='train', to_set='test')
             self.format()
         else:
             raise AttributeError('repo_path not specified in config')

--- a/neon/datasets/sparsenet.py
+++ b/neon/datasets/sparsenet.py
@@ -122,7 +122,7 @@ class SPARSENET(Dataset):
                     logger.error('problems loading: %s', name)
             if hasattr(self, 'validation_pct'):
                 self.split_set(
-                    self.validation_pct, from_set='train', to_set='test')
+                    self.validation_pct, from_set='train', to_set='validation')
             self.format()
         else:
             raise AttributeError('repo_path not specified in config')

--- a/neon/datasets/synthetic.py
+++ b/neon/datasets/synthetic.py
@@ -60,7 +60,7 @@ class UniformRandom(Dataset):
             self.load_data((self.ntrain, self.nin)))
         self.inputs['test'], self.targets['test'] = (
             self.load_data((self.ntest, self.nin)))
-        if self.validation_pct:
+        if hasattr(self, 'validation_pct'):
             self.split_set(
                 self.validation_pct, from_set='train', to_set='validation')
         self.format()
@@ -143,7 +143,7 @@ class ToyImages(Dataset):
         self.targets['train'] = targets[inds[:self.ntrain]]
         self.inputs['test'] = data[inds[self.ntrain:]]
         self.targets['test'] = targets[inds[self.ntrain:]]
-        if self.validation_pct:
+        if hasattr(self, 'validation_pct'):
             self.split_set(
                 self.validation_pct, from_set='train', to_set='validation')
         self.format()

--- a/neon/datasets/synthetic.py
+++ b/neon/datasets/synthetic.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 
 
 class UniformRandom(Dataset):
+
     """
     Sets up a synthetic uniformly random dataset.
 
@@ -59,10 +60,14 @@ class UniformRandom(Dataset):
             self.load_data((self.ntrain, self.nin)))
         self.inputs['test'], self.targets['test'] = (
             self.load_data((self.ntest, self.nin)))
+        if self.validation_pct:
+            self.split_set(
+                self.validation_pct, from_set='train', to_set='validation')
         self.format()
 
 
 class ToyImages(Dataset):
+
     """
     Sets up a synthetic image classification dataset.
 
@@ -72,6 +77,7 @@ class ToyImages(Dataset):
         targets (dict): structure housing the loaded train/test/validation
                         target data
     """
+
     def __init__(self, **kwargs):
         self.__dict__.update(kwargs)
         self.macro_batched = False
@@ -137,4 +143,7 @@ class ToyImages(Dataset):
         self.targets['train'] = targets[inds[:self.ntrain]]
         self.inputs['test'] = data[inds[self.ntrain:]]
         self.targets['test'] = targets[inds[self.ntrain:]]
+        if self.validation_pct:
+            self.split_set(
+                self.validation_pct, from_set='train', to_set='validation')
         self.format()

--- a/neon/datasets/tests/test_val_split.py
+++ b/neon/datasets/tests/test_val_split.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from math import ceil
+from nose.plugins.attrib import attr
+
+from neon.datasets.synthetic import UniformRandom, ToyImages
+from neon.backends.cpu import CPU
+from neon.backends.par import NoPar
+
+
+class TestValidationUniformRandom(object):
+
+    @attr('slow')
+    def test_split(self):
+        split = 10
+        batch_size = 10
+        ntrain, ntest, nin, nout = 100, 10, 10, 5
+        data = UniformRandom(ntrain, ntest, nin, nout, validation_pct=split)
+        data.backend = CPU(rng_seed=0)
+        data.backend.actual_batch_size = batch_size
+        par = NoPar()
+        par.associate(data.backend)
+        data.load()
+        split /= 100.0
+        nb_batches = ntrain // batch_size
+        expected_nb_train = ceil((1.0 - split) * nb_batches)
+        expected_nb_valid = nb_batches - expected_nb_train
+        assert expected_nb_train == len(data.inputs['train'])
+        assert expected_nb_train == len(data.targets['train'])
+        assert expected_nb_valid == len(data.inputs['validation'])
+        assert expected_nb_valid == len(data.targets['validation'])
+
+    def test_round_split(self):
+        split = 10
+        batch_size = 32
+        ntrain, ntest, nin, nout = 100, 10, 10, 5
+        data = UniformRandom(ntrain, ntest, nin, nout, validation_pct=split)
+        data.backend = CPU(rng_seed=0)
+        data.backend.actual_batch_size = batch_size
+        par = NoPar()
+        par.associate(data.backend)
+        data.load()
+        split /= 100.0
+        nb_batches = ntrain // batch_size
+        expected_nb_train = ceil((1.0 - split) * nb_batches)
+        expected_nb_valid = nb_batches - expected_nb_train
+        assert expected_nb_train == len(data.inputs['train'])
+        assert expected_nb_train == len(data.targets['train'])
+        assert expected_nb_valid == len(data.inputs['validation'])
+        assert expected_nb_valid == len(data.targets['validation'])
+
+
+class TestValidationToyImages(object):
+
+    @attr('slow')
+    def test_split(self):
+        split = 10
+        batch_size = 32
+        data = ToyImages(validation_pct=split)
+        data.backend = CPU(rng_seed=0)
+        data.backend.actual_batch_size = batch_size
+        par = NoPar()
+        par.associate(data.backend)
+        data.load()
+        ntrain = sum(a.shape[1] for a in data.inputs['train'])
+        split /= 100.0
+        nb_batches = ntrain // batch_size
+        expected_nb_train = ceil((1.0 - split) * nb_batches)
+        expected_nb_valid = nb_batches - expected_nb_train
+        assert expected_nb_train == len(data.inputs['train'])
+        assert expected_nb_train == len(data.targets['train'])
+        assert expected_nb_valid == len(data.inputs['validation'])
+        assert expected_nb_valid == len(data.targets['validation'])
+
+    def test_round_split(self):
+        pass
+
+if __name__ == '__main__':
+    test = TestValidationToyImages()
+    test.test_split()
+    test.test_round_split()

--- a/neon/datasets/tests/test_val_split.py
+++ b/neon/datasets/tests/test_val_split.py
@@ -74,7 +74,23 @@ class TestValidationToyImages(object):
         assert expected_nb_valid == len(data.targets['validation'])
 
     def test_round_split(self):
-        pass
+        split = 10
+        batch_size = 30
+        data = ToyImages(validation_pct=split)
+        data.backend = CPU(rng_seed=0)
+        data.backend.actual_batch_size = batch_size
+        par = NoPar()
+        par.associate(data.backend)
+        data.load()
+        ntrain = sum(a.shape[1] for a in data.inputs['train'])
+        split /= 100.0
+        nb_batches = ntrain // batch_size
+        expected_nb_train = ceil((1.0 - split) * nb_batches)
+        expected_nb_valid = nb_batches - expected_nb_train
+        assert expected_nb_train == len(data.inputs['train'])
+        assert expected_nb_train == len(data.targets['train'])
+        assert expected_nb_valid == len(data.inputs['validation'])
+        assert expected_nb_valid == len(data.targets['validation'])
 
 if __name__ == '__main__':
     test = TestValidationToyImages()

--- a/neon/datasets/tests/test_val_split.py
+++ b/neon/datasets/tests/test_val_split.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from math import ceil
+from math import floor
 from nose.plugins.attrib import attr
 
 from neon.datasets.synthetic import UniformRandom, ToyImages
@@ -24,8 +24,8 @@ class TestValidationUniformRandom(object):
         data.load()
         split /= 100.0
         nb_batches = ntrain // batch_size
-        expected_nb_train = ceil((1.0 - split) * nb_batches)
-        expected_nb_valid = nb_batches - expected_nb_train
+        expected_nb_train = floor((1.0 - split) * nb_batches)
+        expected_nb_valid = floor(split * nb_batches)
         assert expected_nb_train == len(data.inputs['train'])
         assert expected_nb_train == len(data.targets['train'])
         assert expected_nb_valid == len(data.inputs['validation'])
@@ -43,8 +43,11 @@ class TestValidationUniformRandom(object):
         data.load()
         split /= 100.0
         nb_batches = ntrain // batch_size
-        expected_nb_train = ceil((1.0 - split) * nb_batches)
-        expected_nb_valid = nb_batches - expected_nb_train
+        expected_nb_train = floor((1.0 - split) * nb_batches)
+        expected_nb_valid = floor(split * nb_batches)
+        """
+        HERE there's a problem... Probably for
+        """
         assert expected_nb_train == len(data.inputs['train'])
         assert expected_nb_train == len(data.targets['train'])
         assert expected_nb_valid == len(data.inputs['validation'])
@@ -63,11 +66,11 @@ class TestValidationToyImages(object):
         par = NoPar()
         par.associate(data.backend)
         data.load()
-        ntrain = sum(a.shape[1] for a in data.inputs['train'])
+        ntrain = data.ntrain
         split /= 100.0
         nb_batches = ntrain // batch_size
-        expected_nb_train = ceil((1.0 - split) * nb_batches)
-        expected_nb_valid = nb_batches - expected_nb_train
+        expected_nb_train = floor((1.0 - split) * nb_batches)
+        expected_nb_valid = floor(split * nb_batches)
         assert expected_nb_train == len(data.inputs['train'])
         assert expected_nb_train == len(data.targets['train'])
         assert expected_nb_valid == len(data.inputs['validation'])
@@ -82,17 +85,12 @@ class TestValidationToyImages(object):
         par = NoPar()
         par.associate(data.backend)
         data.load()
-        ntrain = sum(a.shape[1] for a in data.inputs['train'])
+        ntrain = data.ntrain
         split /= 100.0
         nb_batches = ntrain // batch_size
-        expected_nb_train = ceil((1.0 - split) * nb_batches)
-        expected_nb_valid = nb_batches - expected_nb_train
+        expected_nb_train = floor((1.0 - split) * nb_batches)
+        expected_nb_valid = floor(split * nb_batches)
         assert expected_nb_train == len(data.inputs['train'])
         assert expected_nb_train == len(data.targets['train'])
         assert expected_nb_valid == len(data.inputs['validation'])
         assert expected_nb_valid == len(data.targets['validation'])
-
-if __name__ == '__main__':
-    test = TestValidationToyImages()
-    test.test_split()
-    test.test_round_split()


### PR DESCRIPTION
Adds split_set method to Dataset, which is called within the load method of datasets. This PR includes the comments from #58. It is tested on both synthetic datasets.

One thing I did differently, was to keep the `amount` parameter (renamed to pct) so that it is possible to create multiple validation sets with a different amount of data.

One final note: every datasets was changed except Imageset and DelimFiles. I believe the method will not work or is not useful for both of them. 