### PR TITLE
Filled in variable name in declaration line

### DIFF
--- a/neon/backends/float_ew.py
+++ b/neon/backends/float_ew.py
@@ -302,7 +302,7 @@ __device__ __forceinline__ short fp32_to_int16(float val)
         "u2": r"""
 __device__ __forceinline__ unsigned short fp32_to_uint16(float val)
 {
-    unsigned short;
+    unsigned short ret;
     asm("cvt.rni.u16.f32 %0, %1;" : "=h"(ret) : "f"(val));
     return ret;
 }

--- a/neon/backends/float_ew.py
+++ b/neon/backends/float_ew.py
@@ -453,7 +453,7 @@ _ew_strings = {
         },
         "nearest": {
             "f2": "unsigned short {0} = fp32_to_fp16({1});",
-            "u4": "unsignedint {0}    = fp32_to_uint32({1});",
+            "u4": "unsigned int {0}    = fp32_to_uint32({1});",
             "u2": "unsigned short {0} = fp32_to_uint16({1});",
             "u1": "unsigned char {0}  = fp32_to_uint8({1});",
             "i4": "int {0}            = fp32_to_int32({1});",


### PR DESCRIPTION
Declaration on line 302 of float_ew.py is incomplete, preventing compilation of certain kernels. Credit to Kyle F for locating and squashing.