### PR TITLE
Fix Callback parameter in IMDB LSTM example

### DIFF
--- a/examples/imdb_lstm.py
+++ b/examples/imdb_lstm.py
@@ -93,7 +93,7 @@ optimizer = Adagrad(learning_rate=0.01, clip_gradients=clip_gradients)
 
 
 # configure callbacks
-callbacks = Callbacks(model, train_set, args, valid_set=valid_set)
+callbacks = Callbacks(model, train_set, args, eval_set=valid_set)
 
 # train model
 model.fit(train_set,


### PR DESCRIPTION
Traceback (most recent call last):
  File "imdb_lstm.py", line 96, in <module>
    callbacks = Callbacks(model, train_set, args, valid_set=valid_set)
TypeError: __init__() got an unexpected keyword argument 'valid_set'