### PR TITLE
Makefile changes to simplify builds for default CUDA installations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,24 @@ RELEASE := $(strip $(shell grep '^VERSION *=' setup.py | cut -f 2 -d '=' \
 # set this to false to turn off GPU related functionality
 HAS_GPU := $(shell nvcc --version > /dev/null 2>&1 && echo true)
 
+ifdef HAS_GPU
+# Get CUDA_ROOT for LD_RUN_PATH
+export CUDA_ROOT:=$(patsubst %/bin/nvcc,%, $(realpath $(shell which nvcc)))
+else
+# Try to find CUDA.  Kernels will still need nvcc in path
+export CUDA_ROOT:=$(firstword $(wildcard $(addprefix /usr/local/, cuda-7.5 cuda-7.0 cuda)))
+
+ifdef CUDA_ROOT
+export PATH:=$(CUDA_ROOT)/bin:$(PATH)
+HAS_GPU := $(shell $(CUDA_ROOT)/bin/nvcc --version > /dev/null 2>&1 && echo true)
+endif
+endif
+ifdef CUDA_ROOT
+# Compiling with LD_RUN_PATH eliminates the need for LD_LIBRARY_PATH
+# when running
+export LD_RUN_PATH:=$(CUDA_ROOT)/lib64
+endif
+
 # set this to true to install visualization dependencies and functionality
 # (off by default)
 VIS :=


### PR DESCRIPTION
The default installation of CUDA does not put nvcc in the path, so the HAS_GPU test fails in the Makefile.  This change looks for 7.5 or 7.0 in /usr/local if nvcc isn't in the path.

pycuda needs CUDA_ROOT set when building.  If nvcc is in the path, CUDA_ROOT is set by stripping off bin/nvcc; if a cuda installation is found, that is used.

By also setting LD_RUN_PATH during the build, pycuda will be able to find the shared libraries if LD_LIBRARY_PATH or other provisions have not been made.

To eliminate the need for adding nvcc to the path, I tried adding a link from .venv/bin/nvcc to $CUDA_ROOT/bin/nvcc, but that is not sufficient to make the examples able to build their kernels.  I think it would be convenient if activate could also take care of this.