### PR TITLE
Parameter alpha is not found in Explin

### DIFF
--- a/neon/transforms/__init__.py
+++ b/neon/transforms/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ----------------------------------------------------------------------------
-from neon.transforms.activation import (Identity, Rectlin, Softmax, Tanh,
+from neon.transforms.activation import (Identity, Explin, Rectlin, Softmax, Tanh,
                                         Logistic, Normalizer)
 from neon.transforms.cost import (CrossEntropyBinary, CrossEntropyMulti,
                                   SumSquared, MeanSquared, LogLoss,

--- a/neon/transforms/activation.py
+++ b/neon/transforms/activation.py
@@ -49,6 +49,7 @@ class Explin(Transform):
     """
     def __init__(self, alpha=1.0, name='elu'):
         super(Explin, self).__init__(name)
+        self.alpha = alpha
 
     def __call__(self, x):
         return self.be.maximum(x, 0) + self.alpha * (self.be.exp(self.be.minimum(x, 0)) - 1)


### PR DESCRIPTION
This pull request resolves a bag in the new activation function, `neon.transforms.activation.Explin`.
The parameter `alpha` is not found in Explin class.

```
Traceback (most recent call last):
  File "./i_love_elu.py", line 67, in <module>
    callbacks=callbacks)
  File "/home/kohei/anaconda2/lib/python2.7/site-packages/neon/models/model.py", line 120, in fit
    self._epoch_fit(dataset, callbacks)
  File "/home/kohei/anaconda2/lib/python2.7/site-packages/neon/models/model.py", line 141, in _epoch_fit
    x = self.fprop(x)
  File "/home/kohei/anaconda2/lib/python2.7/site-packages/neon/models/model.py", line 171, in fprop
    return self.layers.fprop(x, inference)
  File "/home/kohei/anaconda2/lib/python2.7/site-packages/neon/layers/container.py", line 103, in fprop
    x = l.fprop(x, inference)
  File "/home/kohei/anaconda2/lib/python2.7/site-packages/neon/layers/layer.py", line 751, in fprop
    self.outputs[:] = self.transform(self.inputs)
  File "/home/kohei/anaconda2/lib/python2.7/site-packages/neon/transforms/activation.py", line 54, in __call__
    return self.be.maximum(x, 0) + self.alpha * (self.be.exp(self.be.minimum(x, 0)) - 1)
AttributeError: 'Explin' object has no attribute 'alpha'
```