### PR TITLE
PreTrained initializer

### DIFF
--- a/doc/source/initializers.rst
+++ b/doc/source/initializers.rst
@@ -47,3 +47,8 @@ Orthonormal
 -------------
 .. autosummary::
    neon.initializers.initializer.Orthonormal
+
+PreTrained
+-------------
+.. autosummary::
+   neon.initializers.initializer.PreTrained

--- a/neon/initializers/__init__.py
+++ b/neon/initializers/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 from neon.initializers.initializer import (Constant, Uniform, Gaussian, GlorotUniform, Xavier,
-                                           Orthonormal)
+                                           Orthonormal, PreTrained)

--- a/neon/initializers/initializer.py
+++ b/neon/initializers/initializer.py
@@ -128,3 +128,20 @@ class Orthonormal(Initializer):
         # pick the one with the correct shape
         q = u if u.shape == param.shape else v
         param[:] = self.scale * q
+
+
+class PreTrained(Initializer):
+    """
+    A class for initializing parameter tensors with a matrix of pre-trained values.
+
+    for example initializing a LookupTable with values from word2vec
+
+    Args:
+        val (np.array, optional): The array to assign the tensors
+    """
+    def __init__(self, array, name="pre-trained"):
+        super(PreTrained, self).__init__(name=name)
+        self.array = array
+
+    def fill(self, param):
+        param.fill(self.be.array(self.array).T)

--- a/neon/layers/tree/initializer.py
+++ b/neon/layers/tree/initializer.py
@@ -1,0 +1,19 @@
+__author__ = 'bam4d'
+
+from neon.initializers.initializer import Initializer
+
+
+class PreTrained(Initializer):
+    """
+    A class for initializing parameter tensors with a matrix of pre-trained values.
+    for example word2vec
+
+    Args:
+        val (np.array, optional): The array to assign the tensors
+    """
+    def __init__(self, array, name="pre-trained"):
+        super(PreTrained, self).__init__(name=name)
+        self.array = array
+
+    def fill(self, param):
+        param.fill(self.be.array(self.array).T)


### PR DESCRIPTION
I'm using this to seed lookup tables with word2vec trained vectors:

```
init_word2vec = PreTrained(word2vec.syn0norm)

layers = [
            LookupTable(vocab_size=len(word2vec.vocab), embedding_dim=word2vec.vector_size, init=init_word2vec), 
            .........
         ]

```

PreTrained probably is not the best name.. maybe Copy?

Fixed the history issues in my branch