### PR TITLE
check next_error's shape consistant with output

### DIFF
--- a/neon/backends/autodiff.py
+++ b/neon/backends/autodiff.py
@@ -347,6 +347,9 @@ class Autodiff(object):
         self.dtype = be.default_dtype
         if next_error is not None:
             self.next_error = next_error
+            assert next_error.shape == op_tree.shape, (
+                "next_error.shape %s must be consistant with op_tree.shape %s"
+                % (next_error.shape, op_tree.shape))
         else:
             self.next_error = self.be.ones(op_tree.shape)
 


### PR DESCRIPTION
See https://github.com/NervanaSystems/neon/issues/170