### PR TITLE
Add Docker images to docs

### DIFF
--- a/doc/source/user_guide.rst
+++ b/doc/source/user_guide.rst
@@ -118,6 +118,15 @@ When complete, you can deactivate the environment:
     source deactivate
 
 
+Docker
+------
+
+If you would prefer having a containerized installation of neon and its dependencies, the open source community has contributed the following Docker images (note that these are not supported/maintained by Nervana):
+
+* `neon (CPU-only) <https://hub.docker.com/r/kaixhin/neon/>`_
+* `cuda-neon <https://hub.docker.com/r/kaixhin/cuda-neon/>`_
+
+
 Support
 -------
 For any bugs or feature requests please:


### PR DESCRIPTION
Now that https://github.com/NervanaSystems/neon/issues/186 is fixed and both CPU/CUDA Docker images are working I've added them to the docs (using the same wording as in the [0.9.0 docs](http://neon.nervanasys.com/docs/0.9.0/installation.html#docker-images)).