### PR TITLE
Add support for FreeBSD

### DIFF
--- a/neon/data/loader/Makefile
+++ b/neon/data/loader/Makefile
@@ -20,6 +20,10 @@ INC := $(shell pkg-config --cflags opencv)
 LDIR := $(shell pkg-config --libs-only-L opencv)
 LIBS := $(shell pkg-config --libs-only-l opencv)
 CC := g++
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),FreeBSD)
+	CC := clang++
+endif
 OPENCVPKG := $(shell pkg-config --list-all | grep -e '^opencv' | cut -d' ' -f1)
 
 ifeq ($(LDIR),)


### PR DESCRIPTION
Tested in FreeBSD 10.2, clang 3.7, g++ will not compile.
To install dependencies, use the command:
```
pkg install py27-virtualenv py27-pip hdf5 libyaml opencv
```
