### PR TITLE
fix conv/deconv tests for CPU execution and fix i32 data type

### DIFF
--- a/tests/test_conv_layer.py
+++ b/tests/test_conv_layer.py
@@ -19,10 +19,15 @@ import itertools as itt
 import numpy as np
 import pytest
 from neon import NervanaObject
-from neon.backends.nervanagpu import NervanaGPU
 from neon.layers.layer import Convolution
 from neon.initializers.initializer import Uniform
 from utils import allclose_with_out
+try:
+    from neon.backends.nervanagpu import NervanaGPU
+except:
+    # stub out the class
+    class NervanaGPU(object):
+        pass
 
 
 def pytest_generate_tests(metafunc):
@@ -344,7 +349,7 @@ class ConvLayerRef(object):
         self.z = np.zeros((mbs, self.nout), dtype=dtypeu)
         self.y = np.zeros((mbs, self.nout), dtype=dtypeu)
         ofmstarts = np.array(list(range(0, (self.ofmsize * nofm), self.ofmsize)))
-        self.ofmlocs = np.zeros((self.ofmsize, nofm), dtype='i32')
+        self.ofmlocs = np.zeros((self.ofmsize, nofm), dtype=np.int32)
         for dst in range(self.ofmsize):
             self.ofmlocs[dst, :] = ofmstarts + dst
         # Figure out the connections with the previous layer.

--- a/tests/test_deconv_layer.py
+++ b/tests/test_deconv_layer.py
@@ -16,9 +16,14 @@ import itertools as itt
 import numpy as np
 import pytest
 from neon import NervanaObject
-from neon.backends.nervanagpu import NervanaGPU
 from neon.layers import Deconvolution
 from neon.initializers import Uniform
+try:
+    from neon.backends.nervanagpu import NervanaGPU
+except:
+    # stub out the class
+    class NervanaGPU(object):
+        pass
 
 
 def pytest_generate_tests(metafunc):
@@ -265,7 +270,7 @@ class DeconvRefLayer(object):
         self.y = np.zeros((mbs, self.nout), dtype=dtypeu)
         ofmstarts = np.array(
             list(range(0, (self.ofmsize * self.nofm), self.ofmsize)))
-        self.ofmlocs = np.zeros((self.ofmsize, self.nofm), dtype='i32')
+        self.ofmlocs = np.zeros((self.ofmsize, self.nofm), dtype=np.int32)
         for dst in range(self.ofmsize):
             self.ofmlocs[dst, :] = ofmstarts + dst
 


### PR DESCRIPTION
When building a CPU-only build, these two tests still require pycuda and scikit-cuda to be installed.  This PR stubs them out.

This also fixes two data types that were 'i32', preferring instead np.int32 as the datatype.  This is more compatible with more recent versions of numpy (tested with 1.11).