### PR TITLE
More general perl shebang, allow to build with numpy 1.12

### DIFF
--- a/neon/backends/kernels/maxas/maxas.pl
+++ b/neon/backends/kernels/maxas/maxas.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use MaxAs::Cubin;
 use MaxAs::MaxAs;

--- a/neon/layers/layer.py
+++ b/neon/layers/layer.py
@@ -1288,7 +1288,7 @@ class Reshape(Layer):
         self.out_shape = list(self.reshape)
 
         if 0 in self.reshape:
-            dim_to_keep = np.where(np.array(self.reshape) == 0)[0]
+            dim_to_keep = np.where(np.array(self.reshape) == 0)[0][0]
             self.out_shape[dim_to_keep] = list(self.in_shape)[dim_to_keep]
 
         if -1 in self.reshape:

--- a/tests/test_backend_autodiff_extra.py
+++ b/tests/test_backend_autodiff_extra.py
@@ -77,12 +77,12 @@ class TestAutodiff(object):
         m = self.m
         n = self.n
         if 'scalar' in flags:
-            m = 1.
-            n = 1.
+            m = 1
+            n = 1
         if 'row' in flags:
-            m = 1.
+            m = 1
         if 'col' in flags:
-            n = 1.
+            n = 1
         # integer
         if 'int' in flags:
             if 'pos' in flags:


### PR DESCRIPTION
Two small changes in this PR:
- Do not hardcode perl path in maxsas shebang.
- Allow to compile against numpy 1.12 by fixing problematic indexing instructions ([see numpy 1.12 notes](https://github.com/numpy/numpy/blob/master/doc/release/1.12.0-notes.rst)).

I needed to apply this patch when building conda packages for neon ([cpu package](https://github.com/loopbio/nervana-neon-feedstock/tree/loopbio-cpu), [gpu package](https://github.com/loopbio/nervana-neon-feedstock)). You can see these changes in action, for example, using this conda environment.

```yaml
name: neon
channels:
  - loopbio
  - conda-forge
  - defaults
dependencies:

  # Pin to latest numpy
  - numpy>=1.12

  # Declare and install perl (for maxas)
  - perl-feature
  - perl

  # Install neon without GPU support
  - neon

  # Install neon with GPU support
  # - cuda-feature=8.0
  # - cuda-dev-feature=8.0
  # - neon-cuda
```
```sh
conda env create -f neon-environment.yaml
source activate neon
python -c 'import neon; print(neon.__version__)'
```