### PR TITLE
Makefiles now check for virtualenv and pkg-config.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,11 @@ MKL_ENGINE  := neon/backends/mklEngine
 # neon compiled objects
 DATA_LOADER := loader
 
+VIRTUALENV := $(shell command -v virtualenv 2> /dev/null)
+ifndef VIRTUALENV
+    $(error "virtualenv must be installed. Consider `pip install virtualenv`.")
+endif
+
 ifeq ($(PY), 2)
 	VIRTUALENV_EXE := virtualenv -p python2.7
 	PYLINT3K_ARGS := --disable=no-absolute-import

--- a/loader/Makefile
+++ b/loader/Makefile
@@ -25,6 +25,11 @@ ifeq ($(UNAME_S), FreeBSD)
 	CC          := clang++
 endif
 
+PKGCONFIG := $(shell command -v pkg-config 2> /dev/null)
+ifndef PKGCONFIG
+    $(error "pkg-config must be installed. Consider `sudo apt-get install pkg-config` or `brew install pkg-config`.")
+endif
+
 ifeq ($(shell pkg-config --exists opencv; echo $$?), 0)
 	IMGFLAG     := -DHAS_IMGLIB
 	CFLAGS      := $(shell pkg-config --cflags opencv) $(CFLAGS)


### PR DESCRIPTION
When installing Neon on a brand-new MacBook Pro running OS X Sierra, I encountered an absence of pkg-config as well as virtualenv. I added checks and error messages to appropriate Makefiles to cover these cases.