### PR TITLE
Add dist to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ neon/version.py
 .styleenv
 .coverage
 build
+dist
 *.gz
 generated
 *.ropeproject


### PR DESCRIPTION
The `dist` dir is created during `python setup.py install`.