### PR TITLE
Bugfix NeonArgparser constructor

### DIFF
--- a/neon/util/argparser.py
+++ b/neon/util/argparser.py
@@ -78,7 +78,7 @@ class NeonArgparser(configargparse.ArgumentParser):
             kwargs['add_config_file_help'] = False
 
         self.defaults = kwargs.pop('default_overrides', dict())
-        super(NeonArgparser, self).__init__(*args, **kwargs)
+        super(NeonArgparser, self).__init__(**kwargs)
 
         # ensure that default values are display via --help
         self.formatter_class = configargparse.ArgumentDefaultsHelpFormatter


### PR DESCRIPTION
Signed-off-by: Gabriel Briones Sayeg <gabriel.briones.sayeg@intel.com>

NeonArgparser inherits from configargparse.ArgumentParser but ArgumentParser takes no positional arguments, this raises an error whenever NeonArgparser is instantiated with a positional argument.

Found this issue in most of the example scripts, here is one: [https://github.com/NervanaSystems/neon/blob/a10f90546d2ddae68c3671f59ba9b513158a91f1/examples/cifar10.py#L37](https://github.com/NervanaSystems/neon/blob/a10f90546d2ddae68c3671f59ba9b513158a91f1/examples/cifar10.py#L37)

This is how you reproduce:
```
$ python3 examples/cifar10.py 
/usr/local/lib64/python3.6/site-packages/h5py/__init__.py:36: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.
  from ._conv import register_converters as _register_converters
Traceback (most recent call last):
  File "examples/cifar10.py", line 37, in <module>
    parser = NeonArgparser(__doc__)
  File "/usr/local/lib/python3.6/site-packages/neon/util/argparser.py", line 80, in __init__
    super(NeonArgparser, self).__init__(*args, **kwargs)
TypeError: __init__() got multiple values for argument 'add_config_file_help'
```
