### PR TITLE
docs: fix simple typo, sclae -> scale

### DIFF
--- a/examples/ssd/mboxloss.py
+++ b/examples/ssd/mboxloss.py
@@ -180,7 +180,7 @@ class MBoxLoss(NervanaObject):
             loc_diff[self.inds_more] = np.sign(loc_diff[self.inds_more])
 
             # backprop the loc loss
-            # sclae the loc_predictions by num_matches
+            # scale the loc_predictions by num_matches
             loc_diff /= float(num_matches)
 
             count = 0


### PR DESCRIPTION
There is a small typo in examples/ssd/mboxloss.py.

Should read `scale` rather than `sclae`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md